### PR TITLE
Renaming IO instructions in the raw AST

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+indent_size = 4

--- a/src/astraw.rs
+++ b/src/astraw.rs
@@ -4,7 +4,7 @@ pub enum RawInstr {
 	Minus,
 	Left,
 	Right,
-	Dot,
-	Comma,
+	Output,
+	Input,
 	BracketLoop(Vec<RawInstr>),
 }

--- a/src/astsoup.rs
+++ b/src/astsoup.rs
@@ -83,8 +83,8 @@ pub fn soupify(raw_prog: &Vec<RawInstr>) -> Vec<SoupInstr> {
 					unreachable!()
 				}
 			}
-			RawInstr::Dot => soup_prog.push(SoupInstr::Output),
-			RawInstr::Comma => soup_prog.push(SoupInstr::Input),
+			RawInstr::Output => soup_prog.push(SoupInstr::Output),
+			RawInstr::Input => soup_prog.push(SoupInstr::Input),
 			RawInstr::BracketLoop(raw_instr_vec) => {
 				let body = soupify(raw_instr_vec);
 				if body.len() == 1 && matches!(body[0], SoupInstr::Soup { .. }) {

--- a/src/ctranspiler.rs
+++ b/src/ctranspiler.rs
@@ -54,8 +54,8 @@ impl TranspiledC {
 				RawInstr::Minus => self.emit_line("m[h]--;"),
 				RawInstr::Left => self.emit_line("h--;"),
 				RawInstr::Right => self.emit_line("h++;"),
-				RawInstr::Dot => self.emit_line("putchar(m[h]);"),
-				RawInstr::Comma => self.emit_line("m[h] = getchar();"),
+				RawInstr::Output => self.emit_line("putchar(m[h]);"),
+				RawInstr::Input => self.emit_line("m[h] = getchar();"),
 				RawInstr::BracketLoop(body) => {
 					self.emit_line("while (m[h])");
 					self.emit_line("{");

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,6 +1,5 @@
-
-use std::collections::HashMap;
 use crate::astsoup::SoupInstr;
+use std::collections::HashMap;
 
 enum BlockInstr {
 	Soup {
@@ -27,7 +26,10 @@ type BlockId = u64;
 
 enum Terminator {
 	Goto(BlockId),
-	Branch { if_zero: BlockId, if_non_zero: BlockId },
+	Branch {
+		if_zero: BlockId,
+		if_non_zero: BlockId,
+	},
 }
 
 struct Block {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,8 +27,8 @@ pub fn parse_instr_seq(src_code: &str) -> Result<Vec<RawInstr>, Vec<ParsingError
 			'-' => scope_stack.top_instr_seq().push(RawInstr::Minus),
 			'<' => scope_stack.top_instr_seq().push(RawInstr::Left),
 			'>' => scope_stack.top_instr_seq().push(RawInstr::Right),
-			'.' => scope_stack.top_instr_seq().push(RawInstr::Dot),
-			',' => scope_stack.top_instr_seq().push(RawInstr::Comma),
+			'.' => scope_stack.top_instr_seq().push(RawInstr::Output),
+			',' => scope_stack.top_instr_seq().push(RawInstr::Input),
 			'[' => scope_stack.0.push(Scope {
 				opening_bracket_pos: Some(pos),
 				instr_seq: Vec::new(),
@@ -154,8 +154,8 @@ impl ParsingError {
 					"{}{}{}{}{}",
 					bold_on, color_light_red, c, color_off, bold_off
 				);
-			} else if matches!(c, '+' | '-' | '<' | '>' | '[' | ']' | '.' | ',')
-				|| c.is_whitespace()
+			} else if matches!(c, '+' | '-' | '<' | '>' | '[' | ']' | '.' | ',') ||
+				c.is_whitespace()
 			{
 				// Print instruction characters normally.
 				print!("{}", c);

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -81,11 +81,11 @@ pub fn run_raw(instr_seq: Vec<RawInstr>, input: Option<Vec<u8>>) -> Vec<u8> {
 				m.head -= 1;
 			}
 			RawInstr::Right => m.head += 1,
-			RawInstr::Dot => {
+			RawInstr::Output => {
 				let char_value = m.get(m.head);
 				m.output_char_value(char_value);
 			}
-			RawInstr::Comma => {
+			RawInstr::Input => {
 				let char_value = m.input_char_value();
 				m.set(m.head, char_value);
 			}


### PR DESCRIPTION
I renamed the IO instructions in the raw AST ("Output" is more explicit than "Dot" x))
Also added an editor configuration for github to display tabs nicely (tabs are 4 columns wide instead of 8) 